### PR TITLE
Add useful and userland apps for Anthropic computer use demo

### DIFF
--- a/template/e2b.Dockerfile
+++ b/template/e2b.Dockerfile
@@ -55,3 +55,52 @@ COPY ./Xauthority /home/user/.Xauthority
 
 COPY ./start-up.sh /
 RUN chmod +x /start-up.sh
+
+RUN apt-get update && \
+  apt-get -y upgrade && \
+  apt-get -y install \
+  build-essential \
+  # UI Requirements
+  xvfb \
+  xterm \
+  xdotool \
+  scrot \
+  imagemagick \
+  sudo \
+  mutter \
+  x11vnc \
+  # Python/pyenv reqs
+  build-essential \
+  libssl-dev  \
+  zlib1g-dev \
+  libbz2-dev \
+  libreadline-dev \
+  libsqlite3-dev \
+  curl \
+  git \
+  libncursesw5-dev \
+  xz-utils \
+  tk-dev \
+  libxml2-dev \
+  libxmlsec1-dev \
+  libffi-dev \
+  liblzma-dev \
+  # Network tools
+  net-tools \
+  netcat \
+  # PPA req
+  software-properties-common && \
+  # Userland apps
+  sudo add-apt-repository ppa:mozillateam/ppa && \
+  sudo apt-get install -y --no-install-recommends \
+  libreoffice \
+  firefox-esr \
+  x11-apps \
+  xpdf \
+  gedit \
+  xpaint \
+  tint2 \
+  galculator \
+  pcmanfm \
+  unzip && \
+  apt-get clean

--- a/template/e2b.toml
+++ b/template/e2b.toml
@@ -1,14 +1,13 @@
 # This is a config for E2B sandbox template.
-# You can use template ID (k0wmnzir0zuzye6dndlw) or template name (desktop) to create a sandbox:
+# You can use 'template_id' (k0wmnzir0zuzye6dndlw) or 'template_name (desktop) from this config to spawn a sandbox:
 
 # Python SDK
-# from e2b import Sandbox, AsyncSandbox
-# sandbox = Sandbox("desktop") # Sync sandbox
-# sandbox = await AsyncSandbox.create("desktop") # Async sandbox
+# from e2b import Sandbox
+# sandbox = Sandbox(template='desktop')
 
 # JS SDK
 # import { Sandbox } from 'e2b'
-# const sandbox = await Sandbox.create('desktop')
+# const sandbox = await Sandbox.create({ template: 'desktop' })
 
 template_id = "k0wmnzir0zuzye6dndlw"
 dockerfile = "e2b.Dockerfile"


### PR DESCRIPTION
This PR adds critical apps for the Anthropic computer user demo:
- xdotool, which is used for automation
- Web browser, word processor, PDF viewer, terminal, etc.

For completeness I added everything used in Anthropic's demo, although for mechanical sympathy I think it makes sense to go back and remove ones (such as scrot and x11vnc) that we probably won't use.

See: https://github.com/anthropics/anthropic-quickstarts/blob/main/computer-use-demo/Dockerfile