### PR TITLE
Update Ubuntu base image to 22.04

### DIFF
--- a/.github/workflows/publish_packages.yml
+++ b/.github/workflows/publish_packages.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   test:
     name: Publish Desktop SDK
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -18,7 +18,7 @@ jobs:
         working-directory: ./template
 
     name: Build and Push Images
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
# Description

There is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
