### PR TITLE
Show SDK ref dir only when it exists in GH publish workflow

### DIFF
--- a/.github/workflows/publish_packages.yml
+++ b/.github/workflows/publish_packages.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: "18.x"
           cache: pnpm
 
       - name: Configure pnpm
@@ -68,9 +68,14 @@ jobs:
       - name: Generate SDK reference
         id: sdk-ref
         run: pnpm run --recursive generate-ref
-    
+
       - name: Show docs file structure
-        run: tree ./sdk-reference
+        run: |
+          if [ -d "./sdk-reference" ]; then
+            tree ./sdk-reference
+          else
+            echo "sdk-reference directory does not exist"
+          fi
 
       - name: Release new versions
         uses: changesets/action@v1


### PR DESCRIPTION
## Description
To avoid errors like [these](https://github.com/e2b-dev/E2B/actions/runs/14200197836/job/39785152642) where we publish without any sdk ref changes.