### PR TITLE
Remove arm64 from template build pipeline

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -37,7 +37,7 @@ jobs:
           docker pull ${{ secrets.DOCKERHUB_USERNAME }}/desktop:latest || true
           docker buildx build \
             --file e2b.Dockerfile \
-            --platform linux/amd64,linux/arm64 \
+            --platform linux/amd64 \
             --push \
             --tag ${{ secrets.DOCKERHUB_USERNAME }}/desktop:latest .
 


### PR DESCRIPTION
# Description

There's no need to build `arm64` template, you have to use `amd64` for building sandbox. Also it's breaking the build and reworking it to make it compatible with would require some extra job, which isn't that beneficial. 

