### PR TITLE
Add view_only and resize to getURL

### DIFF
--- a/.changeset/great-eyes-double.md
+++ b/.changeset/great-eyes-double.md
@@ -1,0 +1,6 @@
+---
+"@e2b/desktop-python": patch
+"@e2b/desktop": patch
+---
+
+Add view_only and resize to getURL

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ desktop = Sandbox()
 # Start the stream
 desktop.stream.start()
 
-# Get stream URL
-url = desktop.stream.get_url()
+# Get stream URL and disable user interaction
+url = desktop.stream.get_url(view_only=True)
 print(url)
 
 # Stop the stream
@@ -110,8 +110,8 @@ const desktop = await Sandbox.create()
 // Start the stream
 await desktop.stream.start()
 
-// Get stream URL
-const url = desktop.stream.getUrl()
+// Get stream URL and disable user interaction
+const url = desktop.stream.getUrl({ viewOnly: true })
 console.log(url)
 
 // Stop the stream

--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ desktop = Sandbox()
 # Start the stream
 desktop.stream.start()
 
+# Get stream URL
+url = desktop.stream.get_url()
+print(url)
+
 # Get stream URL and disable user interaction
 url = desktop.stream.get_url(view_only=True)
 print(url)
@@ -109,6 +113,10 @@ const desktop = await Sandbox.create()
 
 // Start the stream
 await desktop.stream.start()
+
+// Get stream URL
+const url = desktop.stream.getUrl();
+console.log(url);
 
 // Get stream URL and disable user interaction
 const url = desktop.stream.getUrl({ viewOnly: true })

--- a/packages/js-sdk/src/sandbox.ts
+++ b/packages/js-sdk/src/sandbox.ts
@@ -520,6 +520,13 @@ interface VNCServerOptions {
   requireAuth?: boolean;
 }
 
+interface UrlOptions {
+  autoConnect?: boolean;
+  viewOnly?: boolean;
+  resize?: "off" | "scale" | "remote";
+  authKey?: string;
+}
+
 // Modified VNCServer class
 class VNCServer {
   private vncPort: number = 5900;
@@ -572,13 +579,21 @@ class VNCServer {
     );
   }
 
+
   /**
-   * Get the URL to connect to the VNC server.
+   * Get the URL to a web page with a stream of the desktop sandbox.
    * @param autoConnect - Whether to automatically connect to the server after opening the URL.
+   * @param viewOnly - Whether to prevent user interaction through the client.
+   * @param resize - Whether to resize the view when the window resizes.
    * @param authKey - The password to use to connect to the server.
    * @returns The URL to connect to the VNC server.
    */
-  public getUrl({ autoConnect = true, authKey }: { autoConnect?: boolean, authKey?: string } = {}): string {
+  public getUrl({
+    autoConnect = true,
+    viewOnly = false,
+    resize = "scale",
+    authKey
+  }: UrlOptions = {}): string {
     if (this.url === null) {
       throw new Error('Server is not running');
     }
@@ -586,6 +601,12 @@ class VNCServer {
     let url = new URL(this.url);
     if (autoConnect) {
       url.searchParams.set('autoconnect', 'true');
+    }
+    if (viewOnly) {
+      url.searchParams.set('view_only', 'true');
+    }
+    if (resize) {
+      url.searchParams.set('resize', resize);
     }
     if (authKey) {
       url.searchParams.set("password", authKey);

--- a/packages/python-sdk/e2b_desktop/main.py
+++ b/packages/python-sdk/e2b_desktop/main.py
@@ -102,10 +102,14 @@ class _VNCServer:
         characters = string.ascii_letters + string.digits
         return ''.join(secrets.choice(characters) for _ in range(length))
 
-    def get_url(self, auto_connect: bool = True, auth_key: Optional[str] = None) -> str:
+    def get_url(self, auto_connect: bool = True, view_only: bool = False, resize: str = "scale", auth_key: Optional[str] = None) -> str:
         params = []
         if auto_connect:
             params.append("autoconnect=true")
+        if view_only:
+            params.append(f"view_only=true")
+        if resize:
+            params.append(f"resize={resize}")
         if auth_key:
             params.append(f"password={auth_key}")
         if params:

--- a/packages/python-sdk/example.py
+++ b/packages/python-sdk/example.py
@@ -1,0 +1,58 @@
+import os
+import time
+from dotenv import load_dotenv
+import asyncio
+from e2b_desktop import Sandbox
+import math
+import random
+
+# Load environment variables
+load_dotenv()
+
+async def main():
+    print("Starting desktop sandbox...")
+    
+    print("--> Sandbox creation time", end="")
+    start_time = time.time()
+    desktop = Sandbox()
+    end_time = time.time()
+    print(f": {end_time - start_time:.3f}s")
+    
+    print("Desktop Sandbox started, ID:", desktop.sandbox_id)
+    screen_size = desktop.get_screen_size()
+    print("Screen size:", screen_size)
+    
+    desktop.stream.start(
+        require_auth=True
+    )
+    
+    auth_key = desktop.stream.get_auth_key()
+    print("Stream URL:", desktop.stream.get_url(auth_key=auth_key))
+    
+    await asyncio.sleep(5)
+    
+    print("Moving mouse to 'Applications' and clicking...")
+    desktop.move_mouse(100, 100)
+    desktop.left_click()
+    cursor_position = desktop.get_cursor_position()
+    print("Cursor position:", cursor_position)
+    
+    await asyncio.sleep(1)
+    
+    screenshot = desktop.screenshot("bytes")
+    with open('1.png', 'wb') as f:
+        f.write(screenshot)
+    
+    for i in range(20):
+        x = math.floor(random.random() * 1024)
+        y = math.floor(random.random() * 768)
+        desktop.move_mouse(x, y)
+        await asyncio.sleep(2)
+        desktop.right_click()
+        print('right clicked', i)
+    
+    desktop.stream.stop()
+    desktop.kill()
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
I added two important parameters to the stream URL:

- view_only: Used to disable user interaction, false by default
- resize: Automatically scales the stream view to fit the browser window, "scale" by default

I also added an example.py (the same as example.mts but in Python), which is useful when testing changes.