### PR TITLE
Added window management methods, window streaming

### DIFF
--- a/.changeset/pink-words-begin.md
+++ b/.changeset/pink-words-begin.md
@@ -1,0 +1,6 @@
+---
+'@e2b/desktop-python': patch
+'@e2b/desktop': patch
+---
+
+adds window methods and window_id to stream

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+    "singleQuote": true,
+    "semi": false,
+    "trailingComma": "es5"
+  }

--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ Each sandbox is isolated from the others and can be customized with any dependen
 **Basic SDK Examples**
 
 - Check out the examples directory for more examples on how to use the SDK:
-   - [Python](./examples/basic-python)
-   - [JavaScript](./examples/basic-javascript)
+  - [Python](./examples/basic-python)
+  - [JavaScript](./examples/basic-javascript)
 
 **[Open Computer Use](https://github.com/e2b-dev/open-computer-use)**
-   
+
 - Computer use made with 100% open source LLMs.
 
 **[🏄 Surf](https://github.com/e2b-dev/surf)**
 
--  OpenAI Computer Use Agent using E2B's Desktop Sandbox. Runs as a Next.js app.
+- OpenAI Computer Use Agent using E2B's Desktop Sandbox. Runs as a Next.js app.
 
 ## 🚀 Getting started
 
@@ -115,8 +115,8 @@ const desktop = await Sandbox.create()
 await desktop.stream.start()
 
 // Get stream URL
-const url = desktop.stream.getUrl();
-console.log(url);
+const url = desktop.stream.getUrl()
+console.log(url)
 
 // Get stream URL and disable user interaction
 const url = desktop.stream.getUrl({ viewOnly: true })
@@ -173,6 +173,47 @@ console.log(url)
 await desktop.stream.stop()
 ```
 
+### Streaming specific application
+
+**Python**
+
+```python
+from e2b_desktop import Sandbox
+desktop = Sandbox()
+
+# Get current (active) window ID
+window_id = desktop.get_current_window_id()
+
+# Get all windows of the application
+window_ids = desktop.get_application_windows("Firefox")
+
+# Start the stream
+desktop.stream.start(window_id=window_ids[0])
+
+# Stop the stream
+desktop.stream.stop()
+```
+
+**JavaScript**
+
+```javascript
+import { Sandbox } from '@e2b/desktop'
+
+const desktop = await Sandbox.create()
+
+// Get current (active) window ID
+const windowId = await desktop.getCurrentWindowId()
+
+// Get all windows of the application
+const windowIds = await desktop.getApplicationWindows('Firefox')
+
+// Start the stream
+await desktop.stream.start({ windowId: windowIds[0] })
+
+// Stop the stream
+await desktop.stream.stop()
+```
+
 ### Mouse control
 
 **Python**
@@ -212,8 +253,8 @@ await desktop.middleClick(100, 200)
 await desktop.scroll(10) // Scroll by the amount. Positive for up, negative for down.
 await desktop.moveMouse(100, 200) // Move to x, y coordinates
 await desktop.drag([100, 100], [200, 200]) // Drag using the mouse
-await desktop.mousePress("left") // Press the mouse button
-await desktop.mouseRelease("left") // Release the mouse button
+await desktop.mousePress('left') // Press the mouse button
+await desktop.mouseRelease('left') // Release the mouse button
 ```
 
 ### Keyboard control
@@ -251,6 +292,41 @@ await desktop.press('enter')
 await desktop.press('space')
 await desktop.press('backspace')
 await desktop.press(['ctrl', 'c']) // Key combination
+```
+
+### Window control
+
+**Python**
+
+```python
+from e2b_desktop import Sandbox
+desktop = Sandbox()
+
+# Get current (active) window ID
+window_id = desktop.get_current_window_id()
+
+# Get all windows of the application
+window_ids = desktop.get_application_windows("Firefox")
+
+# Get window title
+title = desktop.get_window_title(window_id)
+```
+
+**JavaScript**
+
+```javascript
+import { Sandbox } from '@e2b/desktop'
+
+const desktop = await Sandbox.create()
+
+// Get current (active) window ID
+const windowId = await desktop.getCurrentWindowId()
+
+// Get all windows of the application
+const windowIds = await desktop.getApplicationWindows('Firefox')
+
+// Get window title
+const title = await desktop.getWindowTitle(windowId)
 ```
 
 ### Screenshot
@@ -338,7 +414,7 @@ from e2b_desktop import Sandbox
 desktop = Sandbox()
 
 desktop.wait(1000) # Wait for 1 second
-``` 
+```
 
 **JavaScript**
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,12 @@ await desktop.stream.stop()
 
 ### Streaming specific application
 
+> [!WARNING]
+>
+> - Will raise an error if the desired application is not open yet
+> - The stream will close once the application closes
+> - Creating multiple streams at the same time is not supported, you may have to stop the current stream and start a new one for each application
+
 **Python**
 
 ```python

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -15,6 +15,7 @@ Check out the [example open-source app](https://github.com/e2b-dev/open-computer
 ### Basic SDK usage examples
 
 Check out the examples directory for more examples on how to use the SDK:
+
 - [Python](./examples/basic-python)
 - [JavaScript](./examples/basic-javascript)
 
@@ -45,7 +46,7 @@ const desktop = await Sandbox.create()
 const desktop = await Sandbox.create({
   display: ':0', // Custom display (defaults to :0)
   resolution: [1920, 1080], // Custom resolution
-  dpi: 96 // Custom DPI
+  dpi: 96, // Custom DPI
 })
 ```
 
@@ -92,6 +93,26 @@ console.log(url)
 await desktop.stream.stop()
 ```
 
+### Streaming specific application
+
+```javascript
+import { Sandbox } from '@e2b/desktop'
+
+const desktop = await Sandbox.create()
+
+// Get current (active) window ID
+const windowId = await desktop.getCurrentWindowId()
+
+// Get all windows of the application
+const windowIds = await desktop.getApplicationWindows('Firefox')
+
+// Start the stream
+await desktop.stream.start({ windowId: windowIds[0] })
+
+// Stop the stream
+await desktop.stream.stop()
+```
+
 ### Mouse control
 
 ```javascript
@@ -109,8 +130,8 @@ await desktop.middleClick(100, 200)
 await desktop.scroll(10) // Scroll by the amount. Positive for up, negative for down.
 await desktop.moveMouse(100, 200) // Move to x, y coordinates
 await desktop.drag([100, 100], [200, 200]) // Drag using the mouse
-await desktop.mousePress("left") // Press the mouse button
-await desktop.mouseRelease("left") // Release the mouse button
+await desktop.mousePress('left') // Press the mouse button
+await desktop.mouseRelease('left') // Release the mouse button
 ```
 
 ### Keyboard control
@@ -129,6 +150,23 @@ await desktop.press('enter')
 await desktop.press('space')
 await desktop.press('backspace')
 await desktop.press(['ctrl', 'c']) // Key combination
+```
+
+### Window control
+
+```javascript
+import { Sandbox } from '@e2b/desktop'
+
+const desktop = await Sandbox.create()
+
+// Get current (active) window ID
+const windowId = await desktop.getCurrentWindowId()
+
+// Get all windows of the application
+const windowIds = await desktop.getApplicationWindows('Firefox')
+
+// Get window title
+const title = await desktop.getWindowTitle(windowId)
 ```
 
 ### Screenshot

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -95,6 +95,12 @@ await desktop.stream.stop()
 
 ### Streaming specific application
 
+> [!WARNING]
+>
+> - Will throw an error if the desired application is not open yet
+> - The stream will close once the application closes
+> - Creating multiple streams at the same time is not supported, you may have to stop the current stream and start a new one for each application
+
 ```javascript
 import { Sandbox } from '@e2b/desktop'
 

--- a/packages/js-sdk/src/sandbox.ts
+++ b/packages/js-sdk/src/sandbox.ts
@@ -1,79 +1,86 @@
-import { Sandbox as SandboxBase, SandboxOpts as SandboxOptsBase, CommandHandle, CommandResult, CommandExitError, ConnectionConfig, TimeoutError } from 'e2b'
+import {
+  Sandbox as SandboxBase,
+  SandboxOpts as SandboxOptsBase,
+  CommandHandle,
+  CommandResult,
+  CommandExitError,
+  ConnectionConfig,
+  TimeoutError,
+} from 'e2b'
 
 import { generateRandomString } from './utils'
 
-
 interface CursorPosition {
-  x: number;
-  y: number;
+  x: number
+  y: number
 }
 
 interface ScreenSize {
-  width: number;
-  height: number;
+  width: number
+  height: number
 }
 
 const MOUSE_BUTTONS = {
   left: 1,
   right: 3,
-  middle: 2
+  middle: 2,
 }
 
 const KEYS = {
-  "alt": "Alt_L",
-  "alt_left": "Alt_L",
-  "alt_right": "Alt_R",
-  "backspace": "BackSpace",
-  "break": "Pause",
-  "caps_lock": "Caps_Lock",
-  "cmd": "Super_L",
-  "command": "Super_L",
-  "control": "Control_L",
-  "control_left": "Control_L",
-  "control_right": "Control_R",
-  "ctrl": "Control_L",
-  "del": "Delete",
-  "delete": "Delete",
-  "down": "Down",
-  "end": "End",
-  "enter": "Return",
-  "esc": "Escape",
-  "escape": "Escape",
-  "f1": "F1",
-  "f2": "F2",
-  "f3": "F3",
-  "f4": "F4",
-  "f5": "F5",
-  "f6": "F6",
-  "f7": "F7",
-  "f8": "F8",
-  "f9": "F9",
-  "f10": "F10",
-  "f11": "F11",
-  "f12": "F12",
-  "home": "Home",
-  "insert": "Insert",
-  "left": "Left",
-  "menu": "Menu",
-  "meta": "Meta_L",
-  "num_lock": "Num_Lock",
-  "page_down": "Page_Down",
-  "page_up": "Page_Up",
-  "pause": "Pause",
-  "print": "Print",
-  "right": "Right",
-  "scroll_lock": "Scroll_Lock",
-  "shift": "Shift_L",
-  "shift_left": "Shift_L",
-  "shift_right": "Shift_R",
-  "space": "space",
-  "super": "Super_L",
-  "super_left": "Super_L",
-  "super_right": "Super_R",
-  "tab": "Tab",
-  "up": "Up",
-  "win": "Super_L",
-  "windows": "Super_L"
+  alt: 'Alt_L',
+  alt_left: 'Alt_L',
+  alt_right: 'Alt_R',
+  backspace: 'BackSpace',
+  break: 'Pause',
+  caps_lock: 'Caps_Lock',
+  cmd: 'Super_L',
+  command: 'Super_L',
+  control: 'Control_L',
+  control_left: 'Control_L',
+  control_right: 'Control_R',
+  ctrl: 'Control_L',
+  del: 'Delete',
+  delete: 'Delete',
+  down: 'Down',
+  end: 'End',
+  enter: 'Return',
+  esc: 'Escape',
+  escape: 'Escape',
+  f1: 'F1',
+  f2: 'F2',
+  f3: 'F3',
+  f4: 'F4',
+  f5: 'F5',
+  f6: 'F6',
+  f7: 'F7',
+  f8: 'F8',
+  f9: 'F9',
+  f10: 'F10',
+  f11: 'F11',
+  f12: 'F12',
+  home: 'Home',
+  insert: 'Insert',
+  left: 'Left',
+  menu: 'Menu',
+  meta: 'Meta_L',
+  num_lock: 'Num_Lock',
+  page_down: 'Page_Down',
+  page_up: 'Page_Up',
+  pause: 'Pause',
+  print: 'Print',
+  right: 'Right',
+  scroll_lock: 'Scroll_Lock',
+  shift: 'Shift_L',
+  shift_left: 'Shift_L',
+  shift_right: 'Shift_R',
+  space: 'space',
+  super: 'Super_L',
+  super_left: 'Super_L',
+  super_right: 'Super_R',
+  tab: 'Tab',
+  up: 'Up',
+  win: 'Super_L',
+  windows: 'Super_L',
 }
 
 function mapKey(key: string): string {
@@ -109,12 +116,11 @@ export interface SandboxOpts extends SandboxOptsBase {
   display?: string
 }
 
-
 export class Sandbox extends SandboxBase {
   protected static override readonly defaultTemplate: string = 'desktop'
-  private lastXfce4Pid: number | null = null;
-  readonly display: string;
-  readonly stream: VNCServer;
+  private lastXfce4Pid: number | null = null
+  readonly display: string
+  readonly stream: VNCServer
 
   /**
    * Use {@link Sandbox.create} to create a new Sandbox instead.
@@ -124,14 +130,16 @@ export class Sandbox extends SandboxBase {
    * @internal
    * @access protected
    */
-  constructor(opts: Omit<SandboxOpts, 'timeoutMs' | 'envs' | 'metadata'> & {
-    sandboxId: string;
-    envdVersion?: string;
-  }) {
-    super(opts);
-    this.display = opts.display || ':0';
-    this.lastXfce4Pid = null;
-    this.stream = new VNCServer(this);
+  constructor(
+    opts: Omit<SandboxOpts, 'timeoutMs' | 'envs' | 'metadata'> & {
+      sandboxId: string
+      envdVersion?: string
+    }
+  ) {
+    super(opts)
+    this.display = opts.display || ':0'
+    this.lastXfce4Pid = null
+    this.stream = new VNCServer(this)
   }
   /**
    * Create a new sandbox from the default `desktop` sandbox template.
@@ -183,28 +191,37 @@ export class Sandbox extends SandboxBase {
 
     let sbx
     if (config.debug) {
-      sbx = new this({ sandboxId: 'desktop', ...sandboxOpts, ...config }) as InstanceType<S>
+      sbx = new this({
+        sandboxId: 'desktop',
+        ...sandboxOpts,
+        ...config,
+      }) as InstanceType<S>
     } else {
       const sandbox = await this.createSandbox(
         template,
         sandboxOpts?.timeoutMs ?? this.defaultSandboxTimeoutMs,
         sandboxOpts
       )
-      sbx = new this({ ...sandbox, ...sandboxOpts, ...config }) as InstanceType<S>
+      sbx = new this({
+        ...sandbox,
+        ...sandboxOpts,
+        ...config,
+      }) as InstanceType<S>
     }
 
     const [width, height] = sandboxOpts?.resolution ?? [1024, 768]
     await sbx.commands.run(
       `Xvfb ${sbx.display} -ac -screen 0 ${width}x${height}x24 ` +
-      `-retro -dpi ${sandboxOpts?.dpi ?? 96} -nolisten tcp -nolisten unix`,
+        `-retro -dpi ${sandboxOpts?.dpi ?? 96} -nolisten tcp -nolisten unix`,
       { background: true }
     )
 
     let hasStarted = await sbx.waitAndVerify(
-      `xdpyinfo -display ${sbx.display}`, (r: CommandResult) => r.exitCode === 0
+      `xdpyinfo -display ${sbx.display}`,
+      (r: CommandResult) => r.exitCode === 0
     )
     if (!hasStarted) {
-      throw new TimeoutError("Could not start Xvfb")
+      throw new TimeoutError('Could not start Xvfb')
     }
 
     await sbx.startXfce4()
@@ -226,40 +243,46 @@ export class Sandbox extends SandboxBase {
     timeout: number = 10,
     interval: number = 0.5
   ): Promise<boolean> {
-    let elapsed = 0;
+    let elapsed = 0
 
     while (elapsed < timeout) {
       try {
         if (onResult(await this.commands.run(cmd))) {
-          return true;
+          return true
         }
       } catch (e) {
         if (e instanceof CommandExitError) {
-          continue;
+          continue
         }
-        throw e;
+        throw e
       }
 
-      await new Promise(resolve => setTimeout(resolve, interval * 1000));
-      elapsed += interval;
+      await new Promise((resolve) => setTimeout(resolve, interval * 1000))
+      elapsed += interval
     }
 
-    return false;
+    return false
   }
 
   /**
    * Start xfce4 session if logged out or not running.
    */
   private async startXfce4(): Promise<void> {
-    if (this.lastXfce4Pid === null || (
-      await this.commands.run(
-        `ps aux | grep ${this.lastXfce4Pid} | grep -v grep | head -n 1`
-      )).stdout.trim().includes("[xfce4-session] <defunct>")
+    if (
+      this.lastXfce4Pid === null ||
+      (
+        await this.commands.run(
+          `ps aux | grep ${this.lastXfce4Pid} | grep -v grep | head -n 1`
+        )
+      ).stdout
+        .trim()
+        .includes('[xfce4-session] <defunct>')
     ) {
-      const result = await this.commands.run(
-        "startxfce4", { envs: { DISPLAY: this.display }, background: true }
-      );
-      this.lastXfce4Pid = result.pid;
+      const result = await this.commands.run('startxfce4', {
+        envs: { DISPLAY: this.display },
+        background: true,
+      })
+      this.lastXfce4Pid = result.pid
     }
   }
 
@@ -287,7 +310,9 @@ export class Sandbox extends SandboxBase {
   async screenshot(format: 'stream'): Promise<ReadableStream<Uint8Array>>
   async screenshot(format: 'bytes' | 'blob' | 'stream' = 'bytes') {
     const path = `/tmp/screenshot-${generateRandomString()}.png`
-    await this.commands.run(`scrot --pointer ${path}`, { envs: { DISPLAY: this.display } })
+    await this.commands.run(`scrot --pointer ${path}`, {
+      envs: { DISPLAY: this.display },
+    })
 
     // @ts-expect-error
     const file = await this.files.read(path, { format })
@@ -300,10 +325,12 @@ export class Sandbox extends SandboxBase {
    */
   async leftClick(x?: number, y?: number): Promise<void> {
     if (x && y) {
-      await this.moveMouse(x, y);
+      await this.moveMouse(x, y)
     }
 
-    await this.commands.run("xdotool click 1", { envs: { DISPLAY: this.display } });
+    await this.commands.run('xdotool click 1', {
+      envs: { DISPLAY: this.display },
+    })
   }
 
   /**
@@ -311,10 +338,12 @@ export class Sandbox extends SandboxBase {
    */
   async doubleClick(x?: number, y?: number): Promise<void> {
     if (x && y) {
-      await this.moveMouse(x, y);
+      await this.moveMouse(x, y)
     }
 
-    await this.commands.run("xdotool click --repeat 2 1", { envs: { DISPLAY: this.display } });
+    await this.commands.run('xdotool click --repeat 2 1', {
+      envs: { DISPLAY: this.display },
+    })
   }
 
   /**
@@ -322,10 +351,12 @@ export class Sandbox extends SandboxBase {
    */
   async rightClick(x?: number, y?: number): Promise<void> {
     if (x && y) {
-      await this.moveMouse(x, y);
+      await this.moveMouse(x, y)
     }
 
-    await this.commands.run("xdotool click 3", { envs: { DISPLAY: this.display } });
+    await this.commands.run('xdotool click 3', {
+      envs: { DISPLAY: this.display },
+    })
   }
 
   /**
@@ -333,10 +364,12 @@ export class Sandbox extends SandboxBase {
    */
   async middleClick(x?: number, y?: number): Promise<void> {
     if (x && y) {
-      await this.moveMouse(x, y);
+      await this.moveMouse(x, y)
     }
 
-    await this.commands.run("xdotool click 2", { envs: { DISPLAY: this.display } });
+    await this.commands.run('xdotool click 2', {
+      envs: { DISPLAY: this.display },
+    })
   }
 
   /**
@@ -344,11 +377,14 @@ export class Sandbox extends SandboxBase {
    * @param direction - The direction to scroll. Can be "up" or "down".
    * @param amount - The amount to scroll.
    */
-  async scroll(direction: 'up' | 'down' = 'down', amount: number = 1): Promise<void> {
-    const button = direction === 'up' ? '4' : '5';
-    await this.commands.run(
-      `xdotool click --repeat ${amount} ${button}`, { envs: { DISPLAY: this.display } }
-    );
+  async scroll(
+    direction: 'up' | 'down' = 'down',
+    amount: number = 1
+  ): Promise<void> {
+    const button = direction === 'up' ? '4' : '5'
+    await this.commands.run(`xdotool click --repeat ${amount} ${button}`, {
+      envs: { DISPLAY: this.display },
+    })
   }
 
   /**
@@ -357,23 +393,31 @@ export class Sandbox extends SandboxBase {
    * @param y - The y coordinate.
    */
   async moveMouse(x: number, y: number): Promise<void> {
-    await this.commands.run(
-      `xdotool mousemove --sync ${x} ${y}`, { envs: { DISPLAY: this.display } }
-    );
+    await this.commands.run(`xdotool mousemove --sync ${x} ${y}`, {
+      envs: { DISPLAY: this.display },
+    })
   }
 
   /**
    * Press the mouse button.
    */
-  async mousePress(button: 'left' | 'right' | 'middle' = 'left'): Promise<void> {
-    await this.commands.run(`xdotool mousedown ${MOUSE_BUTTONS[button]}`, { envs: { DISPLAY: this.display } });
+  async mousePress(
+    button: 'left' | 'right' | 'middle' = 'left'
+  ): Promise<void> {
+    await this.commands.run(`xdotool mousedown ${MOUSE_BUTTONS[button]}`, {
+      envs: { DISPLAY: this.display },
+    })
   }
 
   /**
    * Release the mouse button.
    */
-  async mouseRelease(button: 'left' | 'right' | 'middle' = 'left'): Promise<void> {
-    await this.commands.run(`xdotool mouseup ${MOUSE_BUTTONS[button]}`, { envs: { DISPLAY: this.display } });
+  async mouseRelease(
+    button: 'left' | 'right' | 'middle' = 'left'
+  ): Promise<void> {
+    await this.commands.run(`xdotool mouseup ${MOUSE_BUTTONS[button]}`, {
+      envs: { DISPLAY: this.display },
+    })
   }
 
   /**
@@ -382,23 +426,23 @@ export class Sandbox extends SandboxBase {
    * @throws Error if cursor position cannot be determined
    */
   async getCursorPosition(): Promise<CursorPosition> {
-    const result = await this.commands.run(
-      "xdotool getmouselocation", { envs: { DISPLAY: this.display } }
-    );
+    const result = await this.commands.run('xdotool getmouselocation', {
+      envs: { DISPLAY: this.display },
+    })
 
-    const match = result.stdout.match(/x:(\d+)\s+y:(\d+)/);
+    const match = result.stdout.match(/x:(\d+)\s+y:(\d+)/)
     if (!match) {
       throw new Error(
         `Failed to parse cursor position from output: ${result.stdout}`
-      );
+      )
     }
 
-    const [, x, y] = match;
+    const [, x, y] = match
     if (!x || !y) {
-      throw new Error(`Invalid cursor position values: x=${x}, y=${y}`);
+      throw new Error(`Invalid cursor position values: x=${x}, y=${y}`)
     }
 
-    return { x: parseInt(x), y: parseInt(y) };
+    return { x: parseInt(x), y: parseInt(y) }
   }
 
   /**
@@ -407,43 +451,43 @@ export class Sandbox extends SandboxBase {
    * @throws Error if screen size cannot be determined
    */
   async getScreenSize(): Promise<ScreenSize> {
-    const result = await this.commands.run(
-      "xrandr", { envs: { DISPLAY: this.display } }
-    );
+    const result = await this.commands.run('xrandr', {
+      envs: { DISPLAY: this.display },
+    })
 
-    const match = result.stdout.match(/(\d+x\d+)/);
+    const match = result.stdout.match(/(\d+x\d+)/)
     if (!match) {
       throw new Error(
         `Failed to parse screen size from output: ${result.stdout}`
-      );
+      )
     }
 
     try {
-      const [width, height] = match[1].split("x").map(val => parseInt(val));
-      return { width, height };
+      const [width, height] = match[1].split('x').map((val) => parseInt(val))
+      return { width, height }
     } catch (error) {
-      throw new Error(`Invalid screen size format: ${match[1]}`);
+      throw new Error(`Invalid screen size format: ${match[1]}`)
     }
   }
 
   private *breakIntoChunks(text: string, n: number): Generator<string> {
     for (let i = 0; i < text.length; i += n) {
-      yield text.slice(i, i + n);
+      yield text.slice(i, i + n)
     }
   }
 
   private quoteString(s: string): string {
     if (!s) {
-      return "''";
+      return "''"
     }
 
     if (!/[^\w@%+=:,./-]/.test(s)) {
-      return s;
+      return s
     }
 
     // use single quotes, and put single quotes into double quotes
     // the string $'b is then quoted as '$'"'"'b'
-    return "'" + s.replace(/'/g, "'\"'\"'") + "'";
+    return "'" + s.replace(/'/g, "'\"'\"'") + "'"
   }
 
   /**
@@ -455,15 +499,18 @@ export class Sandbox extends SandboxBase {
    */
   async write(
     text: string,
-    options: { chunkSize: number, delayInMs: number } = { chunkSize: 25, delayInMs: 75 }
+    options: { chunkSize: number; delayInMs: number } = {
+      chunkSize: 25,
+      delayInMs: 75,
+    }
   ): Promise<void> {
-    const chunks = this.breakIntoChunks(text, options.chunkSize);
+    const chunks = this.breakIntoChunks(text, options.chunkSize)
 
     for (const chunk of chunks) {
       await this.commands.run(
         `xdotool type --delay ${options.delayInMs} ${this.quoteString(chunk)}`,
         { envs: { DISPLAY: this.display } }
-      );
+      )
     }
   }
 
@@ -478,9 +525,9 @@ export class Sandbox extends SandboxBase {
       key = mapKey(key)
     }
 
-    await this.commands.run(
-      `xdotool key ${key}`, { envs: { DISPLAY: this.display } }
-    );
+    await this.commands.run(`xdotool key ${key}`, {
+      envs: { DISPLAY: this.display },
+    })
   }
 
   /**
@@ -488,11 +535,14 @@ export class Sandbox extends SandboxBase {
    * @param from - The starting position.
    * @param to - The ending position.
    */
-  async drag([x1, y1]: [number, number], [x2, y2]: [number, number]): Promise<void> {
-    await this.moveMouse(x1, y1);
-    await this.mousePress();
-    await this.moveMouse(x2, y2);
-    await this.mouseRelease();
+  async drag(
+    [x1, y1]: [number, number],
+    [x2, y2]: [number, number]
+  ): Promise<void> {
+    await this.moveMouse(x1, y1)
+    await this.mousePress()
+    await this.moveMouse(x2, y2)
+    await this.mouseRelease()
   }
 
   /**
@@ -500,7 +550,9 @@ export class Sandbox extends SandboxBase {
    * @param ms - The amount of time to wait in milliseconds.
    */
   async wait(ms: number): Promise<void> {
-    await this.commands.run(`sleep ${ms / 1000}`, { envs: { DISPLAY: this.display } });
+    await this.commands.run(`sleep ${ms / 1000}`, {
+      envs: { DISPLAY: this.display },
+    })
   }
 
   /**
@@ -508,77 +560,125 @@ export class Sandbox extends SandboxBase {
    * @param fileOrUrl - The file or URL to open.
    */
   async open(fileOrUrl: string): Promise<void> {
-    await this.commands.run(
-      `xdg-open ${fileOrUrl}`, { background: true, envs: { DISPLAY: this.display } }
-    );
+    await this.commands.run(`xdg-open ${fileOrUrl}`, {
+      background: true,
+      envs: { DISPLAY: this.display },
+    })
+  }
+
+  /**
+   * Get the current window ID.
+   * @returns The ID of the current window.
+   */
+  async getCurrentWindowId(): Promise<string> {
+    const result = await this.commands.run('xdotool getwindowfocus', {
+      envs: { DISPLAY: this.display },
+    })
+    return result.stdout.trim()
+  }
+
+  /**
+   * Get the window ID of the window with the given title.
+   * @param title - The title of the window.
+   * @returns The ID of the window.
+   */
+  async getApplicationWindows(application: string): Promise<string[]> {
+    const result = await this.commands.run(
+      `xdotool search --onlyvisible --class ${application}`,
+      {
+        envs: { DISPLAY: this.display },
+      }
+    )
+
+    return result.stdout.trim().split('\n')
+  }
+
+  /**
+   * Get the title of the window with the given ID.
+   * @param windowId - The ID of the window.
+   * @returns The title of the window.
+   */
+  async getWindowTitle(windowId: string): Promise<string> {
+    const result = await this.commands.run(
+      `xdotool getwindowname ${windowId}`,
+      {
+        envs: { DISPLAY: this.display },
+      }
+    )
+
+    return result.stdout.trim()
   }
 }
 
 interface VNCServerOptions {
-  vncPort?: number;
-  port?: number;
-  requireAuth?: boolean;
+  vncPort?: number
+  port?: number
+  requireAuth?: boolean
+  windowId?: string
 }
 
 interface UrlOptions {
-  autoConnect?: boolean;
-  viewOnly?: boolean;
-  resize?: "off" | "scale" | "remote";
-  authKey?: string;
+  autoConnect?: boolean
+  viewOnly?: boolean
+  resize?: 'off' | 'scale' | 'remote'
+  authKey?: string
 }
 
 // Modified VNCServer class
 class VNCServer {
-  private vncPort: number = 5900;
-  private port: number = 6080;
-  private novncAuthEnabled: boolean = false;
-  private url: URL | null = null;
-  private vncHandle: CommandHandle | null = null;
-  private novncHandle: CommandHandle | null = null;
-  private password: string | undefined;
-  private vncCommand: string = "";
-  private readonly novncCommand: string;
-  private readonly desktop: Sandbox;
+  private vncPort: number = 5900
+  private port: number = 6080
+  private novncAuthEnabled: boolean = false
+  private url: URL | null = null
+  private vncHandle: CommandHandle | null = null
+  private novncHandle: CommandHandle | null = null
+  private password: string | undefined
+  private vncCommand: string = ''
+  private readonly novncCommand: string
+  private readonly desktop: Sandbox
 
   constructor(desktop: Sandbox) {
-    this.desktop = desktop;
-    this.novncCommand = (
+    this.desktop = desktop
+    this.novncCommand =
       `cd /opt/noVNC/utils && ./novnc_proxy --vnc localhost:${this.vncPort} ` +
       `--listen ${this.port} --web /opt/noVNC > /tmp/novnc.log 2>&1`
-    );
   }
 
   public getAuthKey(): string {
     if (!this.password) {
-      throw new Error('Unable to retrieve stream auth key, check if requireAuth is enabled');
+      throw new Error(
+        'Unable to retrieve stream auth key, check if requireAuth is enabled'
+      )
     }
 
-    return this.password;
+    return this.password
   }
 
   /**
    * Set the VNC command to start the VNC server.
    */
-  private async setVncCommand(): Promise<void> {
-    let pwdFlag = "-nopw";
+  private async setVncCommand(windowId?: string): Promise<void> {
+    let pwdFlag = '-nopw'
     if (this.novncAuthEnabled) {
-      await this.desktop.commands.run("mkdir ~/.vnc");
-      await this.desktop.commands.run(`x11vnc -storepasswd ${this.password} ~/.vnc/passwd`);
-      pwdFlag = "-usepw";
+      await this.desktop.commands.run('mkdir ~/.vnc')
+      await this.desktop.commands.run(
+        `x11vnc -storepasswd ${this.password} ~/.vnc/passwd`
+      )
+      pwdFlag = '-usepw'
     }
 
-    this.vncCommand = (
+    this.vncCommand =
       `x11vnc -display ${this.desktop.display} -forever -wait 50 -shared ` +
-      `-rfbport ${this.vncPort} ${pwdFlag} 2>/tmp/x11vnc_stderr.log`
-    );
+      `-rfbport ${this.vncPort} ${pwdFlag} 2>/tmp/x11vnc_stderr.log` +
+      (windowId ? ` -id ${windowId}` : '')
   }
 
   private async waitForPort(port: number): Promise<boolean> {
     return await this.desktop.waitAndVerify(
-      `netstat -tuln | grep ":${port} "`, (r: CommandResult) => r.stdout.trim() !== ""
-    );
+      `netstat -tuln | grep ":${port} "`,
+      (r: CommandResult) => r.stdout.trim() !== ''
+    )
   }
-
 
   /**
    * Get the URL to a web page with a stream of the desktop sandbox.
@@ -591,25 +691,25 @@ class VNCServer {
   public getUrl({
     autoConnect = true,
     viewOnly = false,
-    resize = "scale",
-    authKey
+    resize = 'scale',
+    authKey,
   }: UrlOptions = {}): string {
     if (this.url === null) {
-      throw new Error('Server is not running');
+      throw new Error('Server is not running')
     }
 
-    let url = new URL(this.url);
+    let url = new URL(this.url)
     if (autoConnect) {
-      url.searchParams.set('autoconnect', 'true');
+      url.searchParams.set('autoconnect', 'true')
     }
     if (viewOnly) {
-      url.searchParams.set('view_only', 'true');
+      url.searchParams.set('view_only', 'true')
     }
     if (resize) {
-      url.searchParams.set('resize', resize);
+      url.searchParams.set('resize', resize)
     }
     if (authKey) {
-      url.searchParams.set("password", authKey);
+      url.searchParams.set('password', authKey)
     }
     return url.toString()
   }
@@ -620,29 +720,33 @@ class VNCServer {
   public async start(opts: VNCServerOptions = {}): Promise<void> {
     // If both servers are already running, throw an error.
     if (this.vncHandle !== null && this.novncHandle !== null) {
-      throw new Error('Server is already running');
+      throw new Error('Server is already running')
     }
 
-    this.vncPort = opts.vncPort ?? this.vncPort;
-    this.port = opts.port ?? this.port;
-    this.novncAuthEnabled = opts.requireAuth ?? this.novncAuthEnabled;
-    this.password = this.novncAuthEnabled ? generateRandomString() : undefined;
-    this.url = new URL(`https://${this.desktop.getHost(this.port)}/vnc.html`);
+    this.vncPort = opts.vncPort ?? this.vncPort
+    this.port = opts.port ?? this.port
+    this.novncAuthEnabled = opts.requireAuth ?? this.novncAuthEnabled
+    this.password = this.novncAuthEnabled ? generateRandomString() : undefined
+    this.url = new URL(`https://${this.desktop.getHost(this.port)}/vnc.html`)
 
     // Stop both servers in case one of them is running.
-    await this.stop();
+    await this.stop()
 
-    if (this.vncCommand === "") {
-      await this.setVncCommand();
+    if (this.vncCommand === '') {
+      await this.setVncCommand(opts.windowId)
     }
-    this.vncHandle = await this.desktop.commands.run(this.vncCommand, { background: true });
-    if (!await this.waitForPort(this.vncPort)) {
-      throw new Error("Could not start VNC server");
+    this.vncHandle = await this.desktop.commands.run(this.vncCommand, {
+      background: true,
+    })
+    if (!(await this.waitForPort(this.vncPort))) {
+      throw new Error('Could not start VNC server')
     }
 
-    this.novncHandle = await this.desktop.commands.run(this.novncCommand, { background: true });
-    if (!await this.waitForPort(this.port)) {
-      throw new Error("Could not start noVNC server");
+    this.novncHandle = await this.desktop.commands.run(this.novncCommand, {
+      background: true,
+    })
+    if (!(await this.waitForPort(this.port))) {
+      throw new Error('Could not start noVNC server')
     }
   }
 
@@ -651,13 +755,13 @@ class VNCServer {
    */
   public async stop(): Promise<void> {
     if (this.vncHandle) {
-      await this.vncHandle.kill();
-      this.vncHandle = null;
+      await this.vncHandle.kill()
+      this.vncHandle = null
     }
 
     if (this.novncHandle) {
-      await this.novncHandle.kill();
-      this.novncHandle = null;
+      await this.novncHandle.kill()
+      this.novncHandle = null
     }
   }
 }

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -93,6 +93,12 @@ desktop.stream.stop()
 
 ### Streaming specific application
 
+> [!WARNING]
+>
+> - Will raise an error if the desired application is not open yet
+> - The stream will close once the application closes
+> - Creating multiple streams at the same time is not supported, you may have to stop the current stream and start a new one for each application
+
 ```python
 from e2b_desktop import Sandbox
 desktop = Sandbox()

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -15,6 +15,7 @@ Check out the [example open-source app](https://github.com/e2b-dev/open-computer
 ### Basic SDK usage examples
 
 Check out the examples directory for more examples on how to use the SDK:
+
 - [Python](./examples/basic-python)
 - [JavaScript](./examples/basic-javascript)
 
@@ -90,6 +91,25 @@ print(url)
 desktop.stream.stop()
 ```
 
+### Streaming specific application
+
+```python
+from e2b_desktop import Sandbox
+desktop = Sandbox()
+
+# Get current (active) window ID
+window_id = desktop.get_current_window_id()
+
+# Get all windows of the application
+window_ids = desktop.get_application_windows("Firefox")
+
+# Start the stream
+desktop.stream.start(window_id=window_ids[0])
+
+# Stop the stream
+desktop.stream.stop()
+```
+
 ### Mouse control
 
 ```python
@@ -125,6 +145,24 @@ desktop.press("enter")
 desktop.press("space")
 desktop.press("backspace")
 desktop.press(["ctrl", "c"]) # Key combination
+```
+
+### Window control
+
+**Python**
+
+```python
+from e2b_desktop import Sandbox
+desktop = Sandbox()
+
+# Get current (active) window ID
+window_id = desktop.get_current_window_id()
+
+# Get all windows of the application
+window_ids = desktop.get_application_windows("Firefox")
+
+# Get window title
+title = desktop.get_window_title(window_id)
 ```
 
 ### Screenshot


### PR DESCRIPTION
- Adds some window-related methods (`get_current_window_id`, `get_application_windows`, `get_window_title`)
- Adds `window_id` parameter to `desktop.stream.start()`
- Fixes `.stream.stop` (was broken)

### Streaming specific application

**Python**

```python
from e2b_desktop import Sandbox
desktop = Sandbox()

# Get current (active) window ID
window_id = desktop.get_current_window_id()

# Get all windows of the application
window_ids = desktop.get_application_windows("Firefox")

# Start the stream
desktop.stream.start(window_id=window_ids[0])

# Stop the stream
desktop.stream.stop()
```

**JavaScript**

```javascript
import { Sandbox } from '@e2b/desktop'

const desktop = await Sandbox.create()

// Get current (active) window ID
const windowId = await desktop.getCurrentWindowId()

// Get all windows of the application
const windowIds = await desktop.getApplicationWindows('Firefox')

// Start the stream
await desktop.stream.start({ windowId: windowIds[0] })

// Stop the stream
await desktop.stream.stop()
```


### Window controls

**Python**

```python
from e2b_desktop import Sandbox
desktop = Sandbox()

# Get current (active) window ID
window_id = desktop.get_current_window_id()

# Get all windows of the application
window_ids = desktop.get_application_windows("Firefox")

# Get window title
title = desktop.get_window_title(window_id)
```

**JavaScript**

```javascript
import { Sandbox } from '@e2b/desktop'

const desktop = await Sandbox.create()

// Get current (active) window ID
const windowId = await desktop.getCurrentWindowId()

// Get all windows of the application
const windowIds = await desktop.getApplicationWindows('Firefox')

// Get window title
const title = await desktop.getWindowTitle(windowId)
```

> [!WARNING]
>
> - Will throw if the desired window is not open yet
> - The stream will close once the window closes
> - Creating multiple streams at the same time is not supported, you may have to stop the current stream and start a new one for each application
