### PR TITLE
Set timeout for background processes to infinity

### DIFF
--- a/.changeset/neat-trams-draw.md
+++ b/.changeset/neat-trams-draw.md
@@ -1,0 +1,6 @@
+---
+'@e2b/desktop-python': patch
+'@e2b/desktop': patch
+---
+
+Fix timeout for stream background processes

--- a/packages/js-sdk/src/sandbox.ts
+++ b/packages/js-sdk/src/sandbox.ts
@@ -213,7 +213,7 @@ export class Sandbox extends SandboxBase {
     await sbx.commands.run(
       `Xvfb ${sbx.display} -ac -screen 0 ${width}x${height}x24 ` +
         `-retro -dpi ${sandboxOpts?.dpi ?? 96} -nolisten tcp -nolisten unix`,
-      { background: true }
+      { background: true, timeoutMs: 0 }
     )
 
     let hasStarted = await sbx.waitAndVerify(
@@ -281,6 +281,7 @@ export class Sandbox extends SandboxBase {
       const result = await this.commands.run('startxfce4', {
         envs: { DISPLAY: this.display },
         background: true,
+        timeoutMs: 0,
       })
       this.lastXfce4Pid = result.pid
     }
@@ -746,6 +747,7 @@ class VNCServer {
 
     this.novncHandle = await this.desktop.commands.run(this.novncCommand, {
       background: true,
+      timeoutMs: 0,
     })
     if (!(await this.waitForPort(this.port))) {
       throw new Error('Could not start noVNC server')

--- a/packages/python-sdk/e2b_desktop/main.py
+++ b/packages/python-sdk/e2b_desktop/main.py
@@ -162,7 +162,7 @@ class _VNCServer:
 
         self.__desktop.commands.run(vnc_command)
 
-        self.__novnc_handle = self.__desktop.commands.run(novnc_command, background=True)
+        self.__novnc_handle = self.__desktop.commands.run(novnc_command, background=True, timeout=0)
         if not self._wait_for_port(self._port):
             raise TimeoutException("Could not start noVNC server")
 
@@ -231,7 +231,8 @@ class Sandbox(SandboxBase):
         self.commands.run(
             f"Xvfb {self._display} -ac -screen 0 {width}x{height}x24"
             f" -retro -dpi {dpi or 96} -nolisten tcp -nolisten unix",
-            background=True
+            background=True,
+            timeout=0,
         )
 
         if not self._wait_and_verify(
@@ -272,7 +273,7 @@ class Sandbox(SandboxBase):
             self.commands.run(f"ps aux | grep {self._last_xfce4_pid} | grep -v grep | head -n 1").stdout.strip()
         ):
             self._last_xfce4_pid = self.commands.run(
-                "startxfce4", envs={"DISPLAY": self._display}, background=True
+                "startxfce4", envs={"DISPLAY": self._display}, background=True, timeout=0
             ).pid
 
     @property


### PR DESCRIPTION
# Description

The processes timeouts after 60 seconds by default, we use some background processes for setting VNC, setting timeout to 0 will make them run indefinitely.

## Repro example

```ts
import { Sandbox } from '@e2b/desktop'

const desktop = await Sandbox.create()
await desktop.stream.start()
await new Promise(resolve => setTimeout(resolve, 80_000));
await desktop.moveMouse(100, 100)
```