### PR TITLE
Remove first start firefox screen + general improvements for firefox

### DIFF
--- a/template/e2b.Dockerfile
+++ b/template/e2b.Dockerfile
@@ -80,3 +80,8 @@ COPY ./settings.json /home/user/.config/Code/User/settings.json
 COPY ./wallpaper.png /usr/share/backgrounds/xfce/wallpaper.png
 RUN mkdir -p /home/user/.config/xfce4/xfconf/xfce-perchannel-xml/
 COPY ./xfce4-desktop.xml /home/user/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml
+
+# Copy firefox policies
+COPY firefox-policies.json /usr/lib/firefox-esr/distribution/policies.json
+COPY firefox-autoconfig.js /usr/lib/firefox-esr/defaults/pref/autoconfig.js
+COPY firefox.cfg /usr/lib/firefox-esr/firefox.cfg

--- a/template/firefox-autoconfig.js
+++ b/template/firefox-autoconfig.js
@@ -1,0 +1,2 @@
+pref("general.config.filename", "firefox.cfg");
+pref("general.config.obscure_value", 0);

--- a/template/firefox-policies.json
+++ b/template/firefox-policies.json
@@ -1,0 +1,7 @@
+{
+  "policies": {
+    "DisableFirstRunPage": true,
+    "OverrideFirstRunPage": "",
+    "OverridePostUpdatePage": ""
+  }
+}

--- a/template/firefox.cfg
+++ b/template/firefox.cfg
@@ -1,0 +1,31 @@
+// Disable first-run and onboarding
+pref("browser.startup.homepage_override.mstone", "ignore");
+pref("browser.startup.homepage_override.buildID", "");
+pref("browser.aboutwelcome.enabled", false);
+pref("browser.messaging-system.whatsNewPanel.enabled", false);
+
+// Disable Firefox studies and telemetry
+pref("app.shield.optoutstudies.enabled", false);
+pref("app.normandy.enabled", false);
+pref("app.normandy.api_url", "");
+pref("toolkit.telemetry.enabled", false);
+pref("toolkit.telemetry.unified", false);
+pref("toolkit.telemetry.archive.enabled", false);
+pref("datareporting.healthreport.uploadEnabled", false);
+pref("datareporting.policy.dataSubmissionEnabled", false);
+
+// Disable sponsored suggestions in address bar (Firefox Suggest)
+pref("browser.urlbar.suggest.quicksuggest.nonsponsored", false);
+pref("browser.urlbar.suggest.quicksuggest.sponsored", false);
+pref("browser.urlbar.quicksuggest.enabled", false);
+
+// Disable Pocket and all new tab sponsored stuff
+pref("extensions.pocket.enabled", false);
+pref("browser.newtabpage.activity-stream.feeds.section.topstories", false);
+pref("browser.newtabpage.activity-stream.feeds.snippets", false);
+pref("browser.newtabpage.activity-stream.showSponsored", false);
+pref("browser.newtabpage.activity-stream.showSponsoredTopSites", false);
+
+// Disable extension recommendations
+pref("extensions.htmlaboutaddons.recommendations.enabled", false);
+pref("browser.discovery.enabled", false);


### PR DESCRIPTION
# Description

- Removes the welcome screen
- Removes privacy notice
- Removes sponsored sites
- Removes telemetry
- Removes recommendations and suggestions

Before:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/a8545d4a-8728-4f8f-ad78-2fb085ca59e6" />
After:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/5293be34-128f-45d4-817c-d884979e9674" />

