### PR TITLE
Fixes keyboard write when dashes are included

### DIFF
--- a/.changeset/solid-ants-type.md
+++ b/.changeset/solid-ants-type.md
@@ -1,0 +1,6 @@
+---
+'@e2b/desktop-python': patch
+'@e2b/desktop': patch
+---
+
+Uses minus minus in xdotool call to prevent parsing text as flag

--- a/packages/js-sdk/src/sandbox.ts
+++ b/packages/js-sdk/src/sandbox.ts
@@ -509,7 +509,9 @@ export class Sandbox extends SandboxBase {
 
     for (const chunk of chunks) {
       await this.commands.run(
-        `xdotool type --delay ${options.delayInMs} ${this.quoteString(chunk)}`
+        `xdotool type --delay ${options.delayInMs} -- ${this.quoteString(
+          chunk
+        )}`
       )
     }
   }

--- a/packages/python-sdk/e2b_desktop/main.py
+++ b/packages/python-sdk/e2b_desktop/main.py
@@ -543,7 +543,7 @@ class Sandbox(SandboxBase):
 
         for chunk in break_into_chunks(text, chunk_size):
             self.commands.run(
-                f"xdotool type --delay {delay_in_ms} {quote_string(chunk)}"
+                f"xdotool type --delay {delay_in_ms} -- {quote_string(chunk)}"
             )
 
     def press(self, key: Union[str, list[str]]):


### PR DESCRIPTION
- Uses minus minus in xdotool call to prevent parsing text as flag