### PR TITLE
Disable CUA-irrelevant Chrome subsystems to reduce snapshot memory

### DIFF
--- a/template/files/google-chrome.desktop
+++ b/template/files/google-chrome.desktop
@@ -1,10 +1,10 @@
 [Desktop Entry]
 Version=1.0
 Name=Google Chrome
-Exec=/usr/bin/google-chrome-stable --no-first-run --no-default-browser-check --password-store=basic
+Exec=/usr/bin/google-chrome-stable --no-first-run --no-default-browser-check --password-store=basic --disable-extensions --disable-default-apps --disable-sync --disable-spell-check --disable-breakpad --metrics-recording-only --no-pings --mute-audio --disable-features=Autofill,AutofillEnableUpi,PasswordManager,FederatedCredentialsManagement,InterestFeedContentSuggestions,PromotionalTabsEnabled,Translate,TranslateUI,ReadAnything,DistilledPageContent,PictureInPicture,Notifications,WebUSB,WebHID,WebMIDI,WebBluetooth,WebSerial,WebXR,MediaRouter,PaymentRequest,Payments,GlobalMediaControls,MediaSession,WebRTC,WebRtcHWEncoding,BackgroundSync,BackgroundFetch,Push,Prerender2
 Terminal=false
 Icon=google-chrome
 Type=Application
 Categories=Network;WebBrowser;
 MimeType=text/html;text/xml;application/xhtml_xml;x-scheme-handler/http;x-scheme-handler/https;
-StartupWMClass=Google-chrome 
+StartupWMClass=Google-chrome


### PR DESCRIPTION
Add startup flags to google-chrome.desktop that disable Chrome feature subsystems that serve no purpose in a computer-use-agent context. Security features (Safe Browsing, Site Isolation, phishing detection, WebAuthn, component updates, Privacy Sandbox) are deliberately left on because a single sandbox session may load multiple origins in tabs where one could be adversarial.

Measured on a Chrome-only bench build (ubuntu:22.04 + Xvfb + google-chrome-stable, no desktop environment; 3 browse cycles of 5 page navigations each). The absolute deltas are expected to carry over to the full desktop template as they are attributable solely to Chrome's own process memory.
  snapshot memfile:  −87 MB
  snapshot rootfs:   −42 MB
  per-3-cycle memfile overhead: −49 MB
  combined first-snapshot saving: ~129 MB

Flags added and rationale:

--disable-extensions
  The extension system initialises a renderer and on-disk profile
  directory even when no extensions are installed. CUA agents do not
  use extensions.

--disable-default-apps
  Skips the bundled "default app" install step (e.g. Chrome Web Store
  shortcut, Docs, Sheets) that runs on first launch and writes to the
  profile.

--disable-sync
  Prevents the Chrome Sync service from starting. There is no Google
  account in a sandbox; the service polls and writes to disk for
  nothing.

--disable-spell-check
  The Hunspell spell-checker loads dictionary files on startup.
  Agents interact with pages programmatically and have no use for
  in-browser spell checking.

--disable-breakpad
  Disables the Breakpad crash reporter. The crash handler process and
  its shared memory regions are unnecessary in a managed environment
  where crashes are captured at the orchestrator level.

--metrics-recording-only --no-pings
  Keeps Chrome's internal metrics counters working (so nothing crashes
  expecting them) but disables all outbound UMA/UKM uploads and ping
  traffic to Google servers.

--mute-audio
  Prevents Chrome from opening an audio sink. There is no audio device
  in the sandbox; without this flag Chrome still initialises the audio
  subsystem and may log errors or spin waiting for a device.

--disable-features=Autofill,AutofillEnableUpi,PasswordManager,
  FederatedCredentialsManagement
  Autofill and the password manager scan every form field on every
  page load, maintain an in-memory model, and write to the profile
  database. Agents fill forms programmatically via xdotool/CDP.

--disable-features=InterestFeedContentSuggestions,PromotionalTabsEnabled
  Prevents Chrome from fetching and storing content-suggestion feeds
  and from opening promotional NTP tiles, both of which trigger
  background network requests on startup.

--disable-features=Translate,TranslateUI,ReadAnything,DistilledPageContent
  The translation and reading-mode subsystems watch every page load for
  language signals and spin up background tasks. Agents read page
  content via CDP or screenshot, not via Chrome's reader view.

--disable-features=PictureInPicture,Notifications
  Picture-in-picture and the Notifications permission UI are human-
  facing overlays that serve no purpose in a headless-style CUA session.

--disable-features=WebUSB,WebHID,WebMIDI,WebBluetooth,WebSerial,WebXR
  Hardware-access APIs. There is no USB, HID, MIDI, Bluetooth, serial,
  or XR device in the sandbox. Disabling them prevents Chrome from
  enumerating device buses and registering device-arrival watchers.

--disable-features=MediaRouter,GlobalMediaControls,MediaSession
  The Media Router (Chromecast/DIAL discovery), global media controls
  overlay, and Media Session API all initialise background threads and
  mDNS/SSDP listeners that are irrelevant without A/V playback or
  casting targets.

--disable-features=PaymentRequest,Payments
  The Payment Request API handler initialises the payments service and
  loads payment-handler service workers on pages that include
  payment-method metadata. No CUA workflow involves a payment flow.

--disable-features=WebRTC,WebRtcHWEncoding
  WebRTC brings up the ICE agent, STUN/TURN resolution, and hardware
  codec enumeration at browser start even when no page has called
  getUserMedia or RTCPeerConnection. Absent microphone/camera devices
  this is pure overhead.

--disable-features=BackgroundSync
  A Service Worker API that queues "sync" events to be fired when
  network connectivity is restored. Intended for offline-first apps
  (e.g. sending a queued email after reconnecting). The sandbox is
  always online and ephemeral; the sync queue machinery initialises
  regardless.

--disable-features=BackgroundFetch
  Extends BackgroundSync for large transfers that continue after all
  tabs are closed. No CUA session needs multi-hour background downloads
  that outlive the tab.

--disable-features=Push
  The Web Push API. On subscribe, Chrome opens a persistent connection
  to Google's FCM push service and can receive server-pushed messages
  to wake a Service Worker even when the site is not open. The sandbox
  has no push subscriptions and this is pure outbound noise.

--disable-features=Prerender2
  Chrome's speculative pre-rendering: when confident the user will
  navigate to a link, Chrome renders the destination in a hidden
  background renderer process so the transition appears instant. A CUA
  agent navigates programmatically and gains nothing from speculation;
  the hidden renderer consumes a full process worth of memory for a
  page the agent is about to load anyway.