### PR TITLE
Disconnect from fire-and-forget background commands

### DIFF
--- a/.changeset/disconnect-after-run.md
+++ b/.changeset/disconnect-after-run.md
@@ -1,0 +1,6 @@
+---
+"@e2b/desktop": patch
+"@e2b/desktop-python": patch
+---
+
+Disconnect from fire-and-forget background commands. After background `commands.run` calls whose output is never read (`xdg-open`, `gtk-launch`, `Xvfb`, `startxfce4`), the SDK now calls `.disconnect()` so it stops holding the command's event stream open while the process keeps running.

--- a/packages/js-sdk/src/sandbox.ts
+++ b/packages/js-sdk/src/sandbox.ts
@@ -467,9 +467,10 @@ export class Sandbox extends SandboxBase {
    * @param fileOrUrl - The file or URL to open.
    */
   async open(fileOrUrl: string): Promise<void> {
-    await this.commands.run(`xdg-open ${fileOrUrl}`, {
+    const handle = await this.commands.run(`xdg-open ${fileOrUrl}`, {
       background: true,
     })
+    await handle.disconnect()
   }
 
   /**
@@ -511,10 +512,14 @@ export class Sandbox extends SandboxBase {
    * @param uri - The URI to open in the application.
    */
   async launch(application: string, uri?: string): Promise<void> {
-    await this.commands.run(`gtk-launch ${application} ${uri ?? ''}`, {
-      background: true,
-      timeoutMs: 0,
-    })
+    const handle = await this.commands.run(
+      `gtk-launch ${application} ${uri ?? ''}`,
+      {
+        background: true,
+        timeoutMs: 0,
+      }
+    )
+    await handle.disconnect()
   }
 
   protected async _start(display: string, opts?: SandboxOpts): Promise<void> {
@@ -523,11 +528,12 @@ export class Sandbox extends SandboxBase {
     this.stream = new VNCServer(this)
 
     const [width, height] = opts?.resolution ?? [1024, 768]
-    await this.commands.run(
+    const xvfbHandle = await this.commands.run(
       `Xvfb ${display} -ac -screen 0 ${width}x${height}x24 ` +
         `-retro -dpi ${opts?.dpi ?? 96} -nolisten tcp -nolisten unix`,
       { background: true, timeoutMs: 0 }
     )
+    await xvfbHandle.disconnect()
 
     const hasStarted = await this.waitAndVerify(
       `xdpyinfo -display ${display}`,
@@ -559,6 +565,7 @@ export class Sandbox extends SandboxBase {
         timeoutMs: 0,
       })
       this.lastXfce4Pid = result.pid
+      await result.disconnect()
     }
   }
 

--- a/packages/python-sdk/e2b_desktop/main.py
+++ b/packages/python-sdk/e2b_desktop/main.py
@@ -307,9 +307,7 @@ class Sandbox(SandboxBase):
                 f"ps aux | grep {self._last_xfce4_pid} | grep -v grep | head -n 1"
             ).stdout.strip()
         ):
-            xfce4_handle = self.commands.run(
-                "startxfce4", background=True, timeout=0
-            )
+            xfce4_handle = self.commands.run("startxfce4", background=True, timeout=0)
             self._last_xfce4_pid = xfce4_handle.pid
             xfce4_handle.disconnect()
 

--- a/packages/python-sdk/e2b_desktop/main.py
+++ b/packages/python-sdk/e2b_desktop/main.py
@@ -260,12 +260,13 @@ class Sandbox(SandboxBase):
 
         sbx._display = display
         width, height = resolution or (1024, 768)
-        sbx.commands.run(
+        xvfb_handle = sbx.commands.run(
             f"Xvfb {display} -ac -screen 0 {width}x{height}x24"
             f" -retro -dpi {dpi or 96} -nolisten tcp -nolisten unix",
             background=True,
             timeout=0,
         )
+        xvfb_handle.disconnect()
 
         if not sbx._wait_and_verify(
             f"xdpyinfo -display {display}", lambda r: r.exit_code == 0
@@ -306,9 +307,11 @@ class Sandbox(SandboxBase):
                 f"ps aux | grep {self._last_xfce4_pid} | grep -v grep | head -n 1"
             ).stdout.strip()
         ):
-            self._last_xfce4_pid = self.commands.run(
+            xfce4_handle = self.commands.run(
                 "startxfce4", background=True, timeout=0
-            ).pid
+            )
+            self._last_xfce4_pid = xfce4_handle.pid
+            xfce4_handle.disconnect()
 
     @property
     def stream(self) -> _VNCServer:
@@ -511,7 +514,8 @@ class Sandbox(SandboxBase):
 
         :param file_or_url: The file or URL to open.
         """
-        self.commands.run(f"xdg-open {file_or_url}", background=True)
+        handle = self.commands.run(f"xdg-open {file_or_url}", background=True)
+        handle.disconnect()
 
     def get_current_window_id(self) -> str:
         """
@@ -539,6 +543,7 @@ class Sandbox(SandboxBase):
         """
         Launch an application.
         """
-        self.commands.run(
+        handle = self.commands.run(
             f"gtk-launch {application} {uri or ''}", background=True, timeout=0
         )
+        handle.disconnect()


### PR DESCRIPTION
Adds a `.disconnect()` call after every fire-and-forget background `commands.run` in both the JS and Python SDKs — the cases where the command's output stream is never consumed (`xdg-open`, `gtk-launch`, `Xvfb`, and `startxfce4`). Per the e2b SDK, `disconnect()` keeps the process running but stops the SDK from holding the event stream open, avoiding a leaked streaming connection for each backgrounded process. Calls whose output *is* read and the noVNC handle (stored and killed later) are left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)