### PR TITLE
chore(ci): drop unused E2B_API_KEY secret from publish workflow

### DIFF
--- a/.github/workflows/publish_packages.yml
+++ b/.github/workflows/publish_packages.yml
@@ -3,8 +3,6 @@ name: Test Desktop SDK Packages
 on:
   workflow_call:
     secrets:
-      E2B_API_KEY:
-        required: true
       PYPI_TOKEN:
         required: true
 


### PR DESCRIPTION
`publish_packages.yml` declared `E2B_API_KEY` as a `required: true` `workflow_call` secret but never referenced it in any step, so this removes the dead declaration. The only caller, `release.yml`, invokes it with `secrets: inherit`, so no caller-side change is needed.

Note on the branch name: an audit turned up no `E2B_ACCESS_TOKEN` anywhere in the repo — all workflows, SDK/example READMEs, and `.env.example` files already use `E2B_API_KEY`, so no token swap was required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)