### PR TITLE
Upgrade to pnpm 10.34.5 and require 3-day minimum dependency age

### DIFF
--- a/.github/workflows/js-sdk-tests.yml
+++ b/.github/workflows/js-sdk-tests.yml
@@ -30,7 +30,7 @@ jobs:
           prefix: 'tool_version_'
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         id: pnpm-install
         with:
           version: ${{ env.TOOL_VERSION_PNPM }}

--- a/.github/workflows/publish_packages.yml
+++ b/.github/workflows/publish_packages.yml
@@ -47,7 +47,7 @@ jobs:
           virtualenvs-in-project: true
           installer-parallel: true
 
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
         with:
           version: ${{ env.TOOL_VERSION_PNPM }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           prefix: 'tool_version_'
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         id: pnpm-install
         with:
           version: ${{ env.TOOL_VERSION_PNPM }}
@@ -78,7 +78,7 @@ jobs:
           prefix: 'tool_version_'
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         id: pnpm-install
         with:
           version: ${{ env.TOOL_VERSION_PNPM }}

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 nodejs 20.20.2
-pnpm 9.15.9
+pnpm 10.34.5
 python 3.14.7
 poetry 2.4.1

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "format": "pnpm --if-present --recursive run format",
     "changeset": "pnpx @changesets/cli"
   },
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@10.34.5",
   "devDependencies": {
     "@changesets/read": "^0.6.5",
     "changeset": "^0.2.6",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,14 @@
 packages:
   - packages/*
+
+# Only install versions published at least 3 days ago, so compromised releases
+# have time to be pulled from the registry before we pick them up.
+minimumReleaseAge: 4320
+
+# Our own package — we trust it and want new releases immediately.
+minimumReleaseAgeExclude:
+  - e2b
+
+# pnpm 10 no longer runs dependency lifecycle scripts unless allowlisted here.
+onlyBuiltDependencies:
+  - esbuild

--- a/renovate.json5
+++ b/renovate.json5
@@ -9,10 +9,18 @@
   //    "0 * * * *"
   //  ],
   timezone: 'UTC',
+  // Match `minimumReleaseAge` in pnpm-workspace.yaml — Renovate must not propose
+  // versions that pnpm would refuse to install.
+  minimumReleaseAge: '3 days',
   // Always squash PRs when automerging
   automergeType: 'pr',
   automergeStrategy: 'squash',
   packageRules: [
+    {
+      description: 'Our own package — no release-age delay, mirrors minimumReleaseAgeExclude in pnpm-workspace.yaml',
+      matchPackageNames: ['e2b'],
+      minimumReleaseAge: null,
+    },
     {
       description: 'Group and automerge patch updates after CI passes',
       matchUpdateTypes: ['patch'],


### PR DESCRIPTION
Bumps pnpm 9.15.9 → 10.34.5 in `.tool-versions` and `packageManager`, and moves the workflows still on `pnpm/action-setup@v3` to `@v4`.

pnpm 10.16 introduced `minimumReleaseAge`, so this sets it to 3 days (4320 minutes) to give the registry time to pull compromised releases before we install them, excluding our own `e2b` package via `minimumReleaseAgeExclude`. Renovate gets a matching `minimumReleaseAge` (and a matching `e2b` exemption) so it can't propose versions pnpm would then refuse to resolve.

pnpm 10 also stopped running dependency lifecycle scripts by default, so `esbuild` is allowlisted under `onlyBuiltDependencies` — its postinstall links the platform binary tsup needs, and it's the only dep in the tree with a build script.

Verified locally on 10.34.5: `pnpm install --frozen-lockfile` passes with `pnpm-lock.yaml` byte-identical (pnpm 10 keeps lockfileVersion 9.0), and the JS SDK builds, lints, and formats clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)