### PR TITLE
chore: adopt shared e2b-dev/renovate preset

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,49 +1,20 @@
 // configuration options: https://docs.renovatebot.com/configuration-options/
-// list of all presets: https://docs.renovatebot.com/presets-default/
+//
+// Base config (config:recommended, automerge/squash, dependency dashboard,
+// patch-automerge, minor-PR, major-approval, GitHub Actions SHA-pinning) is
+// shared from e2b-dev/renovate.
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: [
-    'config:recommended',
-    ':automergeRequireAllStatusChecks',
-    // keep GitHub Actions pinned to commit SHAs (supply-chain hardening)
-    'helpers:pinGitHubActionDigests',
-  ],
-  dependencyDashboard: true,
-  // let it fly for now, we've got a lot to catch up on
-  //  schedule: [
-  //    "0 * * * *"
-  //  ],
-  timezone: 'UTC',
-  // Match `minimumReleaseAge` in pnpm-workspace.yaml — Renovate must not propose
-  // versions that pnpm would refuse to install.
+  extends: ['local>e2b-dev/renovate'],
+  // Keep in sync with `minimumReleaseAge` in pnpm-workspace.yaml (4320 minutes),
+  // otherwise Renovate proposes versions pnpm then refuses to install.
   minimumReleaseAge: '3 days',
-  // Always squash PRs when automerging
-  automergeType: 'pr',
-  automergeStrategy: 'squash',
   packageRules: [
     {
-      description: 'Our own package — no release-age delay, mirrors minimumReleaseAgeExclude in pnpm-workspace.yaml',
+      // Keep in sync with `minimumReleaseAgeExclude` in pnpm-workspace.yaml.
+      description: 'e2b is our own SDK, so it skips the minimum release age',
       matchPackageNames: ['e2b'],
       minimumReleaseAge: null,
     },
-    {
-      description: 'Group and automerge patch updates after CI passes',
-      matchUpdateTypes: ['patch'],
-      automerge: true,
-      groupName: 'patch-updates',
-    },
-    {
-      description: 'Create PRs for minor updates without automerge',
-      matchUpdateTypes: ['minor'],
-      automerge: false,
-    },
-    {
-      description: 'Require dashboard approval for major updates',
-      matchUpdateTypes: ['major'],
-      dependencyDashboardApproval: true,
-      automerge: false,
-    },
   ],
-  prConcurrentLimit: 3,
-  rebaseWhen: 'auto',
 }


### PR DESCRIPTION
## What

Replaces the inlined Renovate config with the shared preset from [`e2b-dev/renovate`](https://github.com/e2b-dev/renovate) (`extends: ['local>e2b-dev/renovate']`), keeping only the repo-specific overrides. This mirrors how `e2b-dev/code-interpreter` already consumes the preset.

## Why

The previous `renovate.json5` duplicated almost the entire shared preset inline. Centralizing means these settings are maintained in one place across e2b-dev repos.

## Config now inherited from the preset (removed from this repo)

- `config:recommended` + `:automergeRequireAllStatusChecks`
- `dependencyDashboard: true`, `timezone: UTC`
- `automergeType: pr`, `automergeStrategy: squash`
- `prConcurrentLimit: 3`, `rebaseWhen: auto`
- Package rules: patch → grouped `patch-updates` + automerge; minor → PR, no automerge; major → dashboard approval
- (New via preset) `pre-commit` enabled and `gitIgnoredAuthors` ignoring `github-actions[bot]`

## Repo-specific config kept

- `minimumReleaseAge: '3 days'` — overrides the preset's `7 days` to match `minimumReleaseAge: 4320` in `pnpm-workspace.yaml`, so Renovate never proposes a version pnpm would refuse to install.
- `e2b` package rule (`minimumReleaseAge: null`) — our own SDK, matching `minimumReleaseAgeExclude` in `pnpm-workspace.yaml`.

## Behavior change to note

The old config extended `helpers:pinGitHubActionDigests` (plain SHA pin); the preset uses `helpers:pinGitHubActionDigestsToSemver`, so the trailing comment on pinned GitHub Actions `uses:` becomes a clean SemVer (e.g. `v1.2.3`) instead of the resolved tag. This aligns `desktop` with the shared standard.

---
_Generated by [Claude Code](https://claude.ai/code/session_016y74sLfUapvqiLwLb4j4xh)_