### PR TITLE
fix(ci): tag the version bump, survive push races, release on dispatch

### DIFF
--- a/.github/scripts/build_release_itinerary.cjs
+++ b/.github/scripts/build_release_itinerary.cjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+// This script formats the JSON written by `changeset status --output=<file>`
+// as the package list that goes into the release's Slack notifications.
+
+const path = require('path')
+
+// Packages are listed in this order; anything not named here still shows up,
+// under its workspace name, after the ones that are.
+const labels = {
+  '@e2b/desktop': 'JS SDK (@e2b/desktop)',
+  '@e2b/desktop-python': 'Python SDK (e2b-desktop)',
+}
+
+const statusFile = process.argv[2]
+if (!statusFile) {
+  console.error('Usage: build_release_itinerary.cjs <changeset-status.json>')
+  process.exit(1)
+}
+
+const order = Object.keys(labels)
+const rank = (release) => {
+  const index = order.indexOf(release.name)
+  return index === -1 ? order.length : index
+}
+
+const { releases } = require(path.resolve(statusFile))
+const lines = [...releases]
+  .sort((a, b) => rank(a) - rank(b))
+  .map(
+    (release) =>
+      `• ${labels[release.name] ?? release.name} v${release.newVersion}`
+  )
+
+process.stdout.write(lines.join('\n') || '• No packages were published')

--- a/.github/scripts/is_release.sh
+++ b/.github/scripts/is_release.sh
@@ -1,9 +1,17 @@
 #!/bin/sh
 
-# This script checks if the current commit contains changesets.
+# This script checks if the current commit contains changesets that release something.
+#
+# An empty changeset (`changeset add --empty`) is a marker that a change needs no
+# release, so it must not count: it would start a release that publishes nothing,
+# and the version step's only effect — deleting the marker — is a commit the
+# publish workflow deliberately does not push when no tags were created. The
+# marker would survive on the branch and re-trigger a no-op release, with Slack
+# notifications, on every later push. It is instead consumed by the next real
+# release.
 
 set -eu
 
-CHANGES=$(node -e "require('@changesets/read').default(process.cwd()).then(result => console.log(!!result.length))")
+CHANGES=$(node -e "require('@changesets/read').default(process.cwd()).then(result => console.log(result.some(changeset => changeset.releases.length > 0)))")
 
 echo "${CHANGES}"

--- a/.github/workflows/publish_packages.yml
+++ b/.github/workflows/publish_packages.yml
@@ -25,6 +25,9 @@ jobs:
         uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           token: ${{ steps.app-token.outputs.token }}
+          # Full history: the push step below can have to merge a branch that moved
+          # mid-release, and a depth-1 clone has no merge base to merge against.
+          fetch-depth: 0
 
       - name: Parse .tool-versions
         uses: wistia/parse-tool-versions@32f568a4ffd4bfa7720ebf93f171597d1ebc979a # v2.1.1
@@ -123,6 +126,18 @@ jobs:
         if: always()
         run: |
           if [ -z "$(git tag --points-at HEAD)" ]; then
+            if [ "${{ steps.release.outcome }}" = "success" ]; then
+              # Publish exited 0 having tagged nothing. Since a release only starts
+              # when a changeset actually releases a package, `changeset version`
+              # bumped something, so this means those versions are already on the
+              # registry — the tail of an earlier release whose branch push failed.
+              # Re-running cannot fix it: nothing is left to publish, so nothing
+              # will ever be tagged, and staying silent here would report success
+              # on every later push while main keeps the old versions.
+              echo "::error::Publish reported success but tagged nothing, so these versions are already published. A previous release most likely failed to push its version bump; land that commit manually rather than re-running."
+              exit 1
+            fi
+
             echo "Nothing was published; the version bump stays local and the changesets are intact for a re-run."
             exit 0
           fi

--- a/.github/workflows/publish_packages.yml
+++ b/.github/workflows/publish_packages.yml
@@ -98,8 +98,24 @@ jobs:
 
           # `add -A`, not `commit -a`: `changeset version` writes each package's
           # CHANGELOG.md as a new file the first time, which `-a` would drop —
-          # which is why this repo has never committed one.
-          git add -A
+          # which is why this repo has never committed one. Scoped to the paths
+          # versioning touches (.changeset deletions, package.json, CHANGELOG.md,
+          # pyproject.toml via postVersion) rather than the whole tree, so an
+          # untracked file written by an earlier step — a dependency lifecycle
+          # script, a build — cannot ride along into a commit that gets pushed to
+          # main with release credentials. Directories, not explicit file lists,
+          # so a package added later is still covered.
+          git add -A -- .changeset packages
+
+          # The release commit is complete only because the lockfile does not move
+          # at release time, per the note above, so it is deliberately not staged.
+          # If it ever does move, the commit being tagged is missing part of the
+          # release: stop instead of tagging an inconsistent tree.
+          if ! git diff --quiet -- pnpm-lock.yaml; then
+            echo "::error::pnpm-lock.yaml changed while versioning. A cross-package dependency must use 'workspace:^' rather than a version range, or the release commit cannot be complete before publishing."
+            exit 1
+          fi
+
           if git diff --cached --quiet; then
             echo "::error::'changeset version' produced no changes, so there is no version bump to publish or tag."
             exit 1

--- a/.github/workflows/publish_packages.yml
+++ b/.github/workflows/publish_packages.yml
@@ -1,4 +1,4 @@
-name: Test Desktop SDK Packages
+name: Publish Packages
 
 on:
   workflow_call:
@@ -76,7 +76,35 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Commit new versions
+        # Commit before publishing, because `changeset publish` tags whatever HEAD
+        # it publishes from — tagging afterwards is what left every tag on the
+        # commit before its own version bump (SDK-298): `@e2b/desktop@2.3.1`
+        # points at a tree containing 2.3.0. Nothing in the tree references the
+        # artifacts about to be uploaded — no workspace package depends on another
+        # by registry range, so `changeset version` leaves pnpm-lock.yaml
+        # untouched and the release commit is already complete. Keep it that way:
+        # a cross-package dependency must use `workspace:^`, never a version
+        # range, or the lockfile would need a tarball this release has not
+        # uploaded yet. The commit stays local until something is actually
+        # published, so a publish that uploads nothing leaves the branch
+        # untouched and the changesets intact for a re-run.
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # `add -A`, not `commit -a`: `changeset version` writes each package's
+          # CHANGELOG.md as a new file the first time, which `-a` would drop —
+          # which is why this repo has never committed one.
+          git add -A
+          if git diff --cached --quiet; then
+            echo "::error::'changeset version' produced no changes, so there is no version bump to publish or tag."
+            exit 1
+          fi
+          git commit -m "[skip ci] Release new versions"
+
       - name: Release new versions
+        id: release
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           publish: pnpm run publish
@@ -86,14 +114,25 @@ jobs:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
           NPM_TOKEN: '' # See https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868
 
-      - name: Update lock file
-        run: pnpm i --no-link --no-frozen-lockfile
-
-      - name: Commit new versions
+      - name: Push new versions
+        # Gate on the tags rather than on whether the publish step succeeded: they
+        # are what has to end up reachable. `changeset publish` tags at HEAD and the
+        # step above pushes them to origin, so if any exist — even from a publish
+        # that then failed partway — the commit they point at has to land, or they
+        # hang off no branch, which is the SDK-298 breakage this change prevents.
+        if: always()
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -am "[skip ci] Release new versions" || exit 0
-          git push
+          if [ -z "$(git tag --points-at HEAD)" ]; then
+            echo "Nothing was published; the version bump stays local and the changesets are intact for a re-run."
+            exit 0
+          fi
+
+          if ! git push; then
+            # A PR merged mid-release. Merge rather than rebase: the tags already
+            # point at this commit and rewriting it would strand them off the branch.
+            git fetch origin "${GITHUB_REF_NAME}"
+            git merge --no-edit FETCH_HEAD
+            git push
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,11 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
+  # Releases are cut by hand, as in e2b-dev/E2B and e2b-dev/code-interpreter:
+  # merging a changeset to main no longer publishes on its own, so changesets
+  # accumulate until someone dispatches this. A release that publishes nothing
+  # leaves them intact, which makes a re-dispatch the recovery path too.
+  workflow_dispatch: {}
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -21,6 +23,17 @@ jobs:
       python-sdk: ${{ steps.python.outputs.release }}
       itinerary: ${{ steps.itinerary.outputs.itinerary }}
     steps:
+      - name: Check the ref
+        # `workflow_dispatch` offers every branch in the picker, and a feature
+        # branch carrying changesets would otherwise publish real packages and
+        # push the version bump to that branch.
+        if: github.ref != 'refs/heads/main'
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          echo "::error::Releases must run on main; this run is on ${REF}."
+          exit 1
+
       - name: Checkout Repo
         uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
@@ -77,16 +90,12 @@ jobs:
       - name: Build release itinerary
         id: itinerary
         if: steps.version.outputs.release == 'true'
+        # This only feeds the Slack notifications, so it must never be the thing
+        # that blocks a release; the messages fall back to a placeholder.
+        continue-on-error: true
         run: |
           pnpm changeset status --output=.cs-status.json
-          ITINERARY=$(node -e '
-            const data = require("./.cs-status.json");
-            const labels = { "@e2b/desktop": "JS SDK (@e2b/desktop)", "@e2b/desktop-python": "Python SDK (e2b-desktop)" };
-            const order = ["@e2b/desktop", "@e2b/desktop-python"];
-            const byName = Object.fromEntries(data.releases.map(r => [r.name, r]));
-            const lines = order.filter(n => byName[n]).map(n => `• ${labels[n]} v${byName[n].newVersion}`);
-            process.stdout.write(lines.join("\n") || "• No packages were published");
-          ')
+          ITINERARY=$(node ./.github/scripts/build_release_itinerary.cjs .cs-status.json)
           rm -f .cs-status.json
           {
             echo "itinerary<<EOF"
@@ -129,7 +138,7 @@ jobs:
             :rocket: A new release has been triggered :hourglass_flowing_sand:
 
             *Releasing:*
-            ${{ needs.preflight.outputs.itinerary }}
+            ${{ needs.preflight.outputs.itinerary || '• (itinerary unavailable)' }}
           SLACK_TITLE: Release Started
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: 'monitoring-releases'
@@ -165,7 +174,7 @@ jobs:
             :tada: A new version has been released successfully! :ship-it-parrot:
 
             *Released:*
-            ${{ needs.preflight.outputs.itinerary }}
+            ${{ needs.preflight.outputs.itinerary || '• (itinerary unavailable)' }}
           SLACK_TITLE: Release Succeeded
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: 'monitoring-releases'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,59 +12,14 @@ permissions:
   contents: write
 
 jobs:
-  is_release:
-    name: Is release?
+  preflight:
+    name: Release preflight
     runs-on: ubuntu-latest
     outputs:
       release: ${{ steps.version.outputs.release }}
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
-
-      - name: Parse .tool-versions
-        uses: wistia/parse-tool-versions@32f568a4ffd4bfa7720ebf93f171597d1ebc979a # v2.1.1
-        id: tool-versions
-        with:
-          filename: '.tool-versions'
-          uppercase: 'true'
-          prefix: 'tool_version_'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-        id: pnpm-install
-        with:
-          version: ${{ env.TOOL_VERSION_PNPM }}
-
-      - name: Setup Node
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
-        with:
-          node-version: '${{ env.TOOL_VERSION_NODEJS }}'
-          registry-url: "https://registry.npmjs.org"
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Configure pnpm
-        run: |
-          pnpm config set auto-install-peers true
-          pnpm config set exclude-links-from-lockfile true
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Check if new version
-        id: version
-        run: |
-          IS_RELEASE=$(./.github/scripts/is_release.sh)
-          echo "release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
-
-  changes:
-    name: Repository changes
-    needs: [is_release]
-    if: needs.is_release.outputs.release == 'true'
-    runs-on: ubuntu-latest
-    outputs:
       js-sdk: ${{ steps.js.outputs.release }}
       python-sdk: ${{ steps.python.outputs.release }}
+      itinerary: ${{ steps.itinerary.outputs.itinerary }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
@@ -99,27 +54,90 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Check JavasScript SDK Release
+      - name: Check if new version
+        id: version
+        run: |
+          IS_RELEASE=$(./.github/scripts/is_release.sh)
+          echo "release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
+
+      - name: Check JavaScript SDK Release
         id: js
+        if: steps.version.outputs.release == 'true'
         run: |
           IS_RELEASE=$(./.github/scripts/is_release_for_package.sh "@e2b/desktop")
           echo "release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
 
       - name: Check Python SDK Release
         id: python
+        if: steps.version.outputs.release == 'true'
         run: |
           IS_RELEASE=$(./.github/scripts/is_release_for_package.sh "@e2b/desktop-python")
           echo "release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
 
+      - name: Build release itinerary
+        id: itinerary
+        if: steps.version.outputs.release == 'true'
+        run: |
+          pnpm changeset status --output=.cs-status.json
+          ITINERARY=$(node -e '
+            const data = require("./.cs-status.json");
+            const labels = { "@e2b/desktop": "JS SDK (@e2b/desktop)", "@e2b/desktop-python": "Python SDK (e2b-desktop)" };
+            const order = ["@e2b/desktop", "@e2b/desktop-python"];
+            const byName = Object.fromEntries(data.releases.map(r => [r.name, r]));
+            const lines = order.filter(n => byName[n]).map(n => `• ${labels[n]} v${byName[n].newVersion}`);
+            process.stdout.write(lines.join("\n") || "• No packages were published");
+          ')
+          rm -f .cs-status.json
+          {
+            echo "itinerary<<EOF"
+            echo "$ITINERARY"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+  js-tests:
+    name: JS SDK Tests
+    needs: [preflight]
+    if: needs.preflight.outputs.js-sdk == 'true'
+    uses: ./.github/workflows/js-sdk-tests.yml
+    secrets: inherit
+
+  python-tests:
+    name: Python SDK Tests
+    needs: [preflight]
+    if: needs.preflight.outputs.python-sdk == 'true'
+    uses: ./.github/workflows/python-sdk-tests.yml
+    secrets: inherit
+
   publish:
     name: Publish
-    needs: [is_release]
-    if: (!cancelled()) && !contains(needs.*.result, 'failure') && needs.is_release.outputs.release == 'true'
+    needs: [preflight, js-tests, python-tests]
+    if: (!cancelled()) && !contains(needs.*.result, 'failure') && needs.preflight.outputs.release == 'true'
     uses: ./.github/workflows/publish_packages.yml
     secrets: inherit
 
+  report-start:
+    needs: [preflight]
+    if: needs.preflight.outputs.release == 'true'
+    name: Release Started - Slack Notification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release Started - Slack Notification
+        uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58 # v2.4.0
+        env:
+          SLACK_COLOR: '#3aa3e3'
+          SLACK_MESSAGE: |
+            :rocket: A new release has been triggered :hourglass_flowing_sand:
+
+            *Releasing:*
+            ${{ needs.preflight.outputs.itinerary }}
+          SLACK_TITLE: Release Started
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_CHANNEL: 'monitoring-releases'
+
   report-failure:
-    needs: [publish]
+    # Includes preflight so a release that dies before it decides what to ship
+    # still notifies, instead of skipping every downstream job in silence.
+    needs: [preflight, js-tests, python-tests, publish]
     if: failure()
     name: Release Failed - Slack Notification
     runs-on: ubuntu-latest
@@ -130,5 +148,24 @@ jobs:
           SLACK_COLOR: '#ff0000'
           SLACK_MESSAGE: ':here-we-go-again: :bob-the-destroyer: We need :fix-parrot: ASAP :pray:'
           SLACK_TITLE: Release Failed
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_CHANNEL: 'monitoring-releases'
+
+  report-success:
+    needs: [preflight, publish]
+    if: (!cancelled()) && needs.publish.result == 'success'
+    name: Release Succeeded - Slack Notification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release Succeeded - Slack Notification
+        uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58 # v2.4.0
+        env:
+          SLACK_COLOR: '#36a64f'
+          SLACK_MESSAGE: |
+            :tada: A new version has been released successfully! :ship-it-parrot:
+
+            *Released:*
+            ${{ needs.preflight.outputs.itinerary }}
+          SLACK_TITLE: Release Succeeded
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: 'monitoring-releases'


### PR DESCRIPTION
Ports the release-workflow fixes from `e2b-dev/E2B` (#1463, #1469, #1484, #1589, #1619), whose own PR flagged that they applied here too, with the refinements from `e2b-dev/code-interpreter`#327 — and switches this repo to the same process: **releases are cut by dispatching the workflow, not by merging to `main`**.

Every release tag here points at the commit *before* its own version bump (`@e2b/desktop@2.3.1` contains `"version": "2.3.0"`) because `changesets/action` tags whatever HEAD it publishes from, so the version commit now happens *before* the publish — safe here because `changeset version` leaves `pnpm-lock.yaml` untouched (no workspace package depends on a sibling), which also deletes the `Update lock file` step; the push that follows is gated on `git tag --points-at HEAD` and reconciles a non-fast-forward with a merge rather than a rebase, and `git add -A` replaces `commit -am`, which cannot stage the `CHANGELOG.md` files `changeset version` writes fresh — this repo has never committed one. The add is scoped to `.changeset` and `packages` so an untracked file from an earlier step cannot ride along into a commit pushed with release credentials, `pnpm-lock.yaml` moving is now a hard error rather than a silently incomplete release, and `fetch-depth: 0` gives the merge fallback a merge base.

Also included: Slack start/success notifications with a release itinerary (built by `.github/scripts/build_release_itinerary.cjs`, non-blocking, falling back to a placeholder), `is_release` + `changes` collapsed into a single `preflight` job that refuses to run off `main` — `workflow_dispatch` offers every branch in the picker — and the JS/Python SDK test workflows wired in ahead of publish, which the `changes` job was already computing flags for without anything consuming them. Two further bugs are fixed on the way: an empty changeset (`changeset add --empty`) counted as a release, so it would start a no-op publish whose only effect — deleting the marker — is a commit the tag gate deliberately does not push, leaving the marker on `main` to re-trigger a notified no-op release on every later push; and the tag gate exiting `0` after a successful publish that tagged nothing would have reported success forever while `main` kept the old versions, so it now fails and names the manual recovery.

Verified against real `changeset version` and `changeset status` runs locally: the scoped add stages the bump, the deletions and the previously-dropped `CHANGELOG.md` files with nothing left over, `pnpm-lock.yaml` does not move, `is_release.sh` returns `false` for a marker alone and `true` for a marker plus a real changeset, and the itinerary lists an unlisted package rather than silently omitting it. Left alone deliberately: the `pnpm/action-setup` version input, which reads `.tool-versions` here rather than being a drifting hardcoded pin, and retagging the existing releases — moving published tags breaks anyone who pinned them, so builds of those versions should use the npm tarball or PyPI sdist rather than the git tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)