### PR TITLE
docs: fix grammar in basic-python example comment

### DIFF
--- a/examples/basic-python/main.py
+++ b/examples/basic-python/main.py
@@ -9,7 +9,7 @@ import webview
 
 load_dotenv()
 
-window_frame_height = 29  # Additional px to take into the account the window border at the top
+window_frame_height = 29  # Additional px to take into account the window border at the top
 
 def move_around(desktop, width, height):
     for i in range(5):


### PR DESCRIPTION
## Summary

Fix 1 grammar slip in an example comment:

- **examples/basic-python/main.py**: `take into the account the window border` -> `take into account the window border`

"take into the account" should be the fixed phrase "take into account".

Note: the identical sentence also appears in `examples/basic-javascript/index.js` (line 5). I left it alone to keep this PR to exactly what was reported - happy to include it here if you'd prefer both examples stay in sync.

No functional changes - comment only.